### PR TITLE
Update to latest packages

### DIFF
--- a/AutoMoqCore.Tests/AutoMoqCore.Tests.csproj
+++ b/AutoMoqCore.Tests/AutoMoqCore.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/AutoMoqCore.Tests/AutoMoqCore.Tests.csproj
+++ b/AutoMoqCore.Tests/AutoMoqCore.Tests.csproj
@@ -7,12 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="FluentAssertions" Version="5.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/AutoMoqCore.Tests/AutoMoqerTests.cs
+++ b/AutoMoqCore.Tests/AutoMoqerTests.cs
@@ -87,7 +87,7 @@ namespace AutoMoqCore.Tests
 			try {
 
 				var mockedInterface = mocker.Create<IDependency>();
-                mockedInterface.ShouldBeEquivalentTo(typeof(IDependency));
+                mockedInterface.Should().BeEquivalentTo(typeof(IDependency));
 			     
             } catch {
 				errorWasHit = true;

--- a/AutoMoqCore.Tests/ConfigTests.cs
+++ b/AutoMoqCore.Tests/ConfigTests.cs
@@ -13,7 +13,7 @@ namespace AutoMoqCore.Tests
             public void It_should_default_to_loose()
             {
                 var config = new Config();
-                config.MockBehavior.ShouldBeEquivalentTo(MockBehavior.Loose);
+                config.MockBehavior.Should().BeEquivalentTo(MockBehavior.Loose);
             }
         }
     }

--- a/AutoMoqCore.TextFixure.Samples/AutoMoqCore.TextFixure.Samples.csproj
+++ b/AutoMoqCore.TextFixure.Samples/AutoMoqCore.TextFixure.Samples.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/AutoMoqCore/AutoMoqCore.csproj
+++ b/AutoMoqCore/AutoMoqCore.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>AutoMoqCore</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>2.0.0</PackageVersion>
     <Description>AutoMoq(Darren Cauthon) portado para </Description>
     <Title>AutoMoqCore</Title>
     <Authors>Darren Cauthon;Thomas Ribeiro</Authors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommonServiceLocator" Version="2.0.1" />
-    <PackageReference Include="Moq" Version="4.7.145" />
-    <PackageReference Include="Unity" Version="5.3.1" />
+    <PackageReference Include="CommonServiceLocator" Version="2.0.4" />
+    <PackageReference Include="Moq" Version="4.11.0" />
+    <PackageReference Include="Unity" Version="5.10.3" />
   </ItemGroup>
   
   

--- a/AutoMoqCore/Unity/AutoMockingBuilderStrategy.cs
+++ b/AutoMoqCore/Unity/AutoMockingBuilderStrategy.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Builder;
-using Unity.Builder.Strategy;
+using Unity.Strategies;
 
 namespace AutoMoqCore.Unity
 {
@@ -17,7 +17,7 @@ namespace AutoMoqCore.Unity
             this.ioc = ioc;
         }
 
-        public override void PreBuildUp(IBuilderContext context)
+        public override void PreBuildUp(ref BuilderContext context)
         {
             var type = GetTheTypeFromTheBuilderContext(context);
             if (AMockObjectShouldBeCreatedForThisType(type))
@@ -81,9 +81,9 @@ namespace AutoMoqCore.Unity
             return type.Name != "Func`1";
         }
 
-        private static Type GetTheTypeFromTheBuilderContext(IBuilderContext context)
+        private static Type GetTheTypeFromTheBuilderContext(BuilderContext context)
         {
-            return (context.OriginalBuildKey).Type;
+            return context.Type;
         }
 
         private bool ThisTypeIsNotRegistered(Type type)


### PR DESCRIPTION
Hi, I would love to update AutoMoqCore to the latest packages and get that published on NuGet.

I would like to use this package but we need the new version of Unity. Unity changed some namespaces and type names on the BuilderStrategy that breaks the current version of AutoMoqCore with the latest Unity.

Thanks!